### PR TITLE
Remove redundant sentence

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,8 +54,8 @@
 			    <div class="main_cont" id="opportunity">
 			      <div class="top_art_cont">
 			        <p>Developed by a coalition of leading industry stakeholders, the City of San Francisco, and Code for America, the House Facts Standard is a uniform format for reporting government data on the health and safety of residential buildings.</p>					
-					<p>This uniform format allows the data to be used in new and powerful ways. Local governments already do the hard work to inspect residential buildings and enforce health and safety codes. With the House Facts Standard, you can make the full health and safety history for every house and apartment in your city even more usable by citizens. Greater transparency helps keep owners accountable and further incentivizes compliance with regulations that ensure health, safety and habitability.</p>
-					<p>Like <a target="_parent" href="http://foodinspectiondata.us/">other civic data standards</a>, this “machine-readable” format enables the development of apps, visualizations and other tools for making the most out of your government’s work.</p>
+			        <p>This uniform format allows the data to be used in new and powerful ways. Local governments already do the hard work to inspect residential buildings and enforce health and safety codes. With the House Facts Standard, you can make the full health and safety history for every house and apartment in your city even more usable by citizens. Greater transparency helps keep owners accountable and further incentivizes compliance with regulations that ensure health, safety and habitability.</p>
+			        <p>Like <a target="_parent" href="http://foodinspectiondata.us/">other civic data standards</a>, this “machine-readable” format enables the development of apps, visualizations and other tools for making the most out of your government’s work.</p>
 			      </div>
 			</div>
 			<div class="main_cont" id="program">

--- a/index.html
+++ b/index.html
@@ -53,15 +53,9 @@
 				  <div id="finish_line_cont"></div>
 			    <div class="main_cont" id="opportunity">
 			      <div class="top_art_cont">
-			         <p>Developed by a coalition of leading industry stakeholders, the City of San Francisco, and Code for America, the House Facts Standard is a uniform format for reporting government data on the health and safety of residential buildings.</p>
-					
-					<p>This uniform format allows the data to be used in new and powerful ways. Local governments already do the hard work to inspect residential buildings and enforce health and safety codes. With the House Facts Standard, you can make the full health and safety history for every house and apartment in your city even more usable by citizens. Greater transparency helps keep owners accountable and further incentivizes compliance with regulations that ensure health, safety and habitability.
-
-Like other civic data standards, this “machine-readable” format enables the development of apps, visualizations and other tools for making the most out of your government’s work. 
-
-
-
-					<p>Like <a target="_parent" href="http://foodinspectiondata.us/">other civic data standards</a>,  this “machine-readable” format enables the development of apps, visualizations and other tools for making the most out of your government’s work.</p>
+			        <p>Developed by a coalition of leading industry stakeholders, the City of San Francisco, and Code for America, the House Facts Standard is a uniform format for reporting government data on the health and safety of residential buildings.</p>					
+					<p>This uniform format allows the data to be used in new and powerful ways. Local governments already do the hard work to inspect residential buildings and enforce health and safety codes. With the House Facts Standard, you can make the full health and safety history for every house and apartment in your city even more usable by citizens. Greater transparency helps keep owners accountable and further incentivizes compliance with regulations that ensure health, safety and habitability.</p>
+					<p>Like <a target="_parent" href="http://foodinspectiondata.us/">other civic data standards</a>, this “machine-readable” format enables the development of apps, visualizations and other tools for making the most out of your government’s work.</p>
 			      </div>
 			</div>
 			<div class="main_cont" id="program">


### PR DESCRIPTION
On the index, the last sentence in the second paragraph ("Like other civic standards...your government's work") is repeated directly below it in a new paragraph.

This pull request removes the sentence from the second paragraph and cleans up the HTML a bit.
