### PR TITLE
Change destination for the data download link

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
 						</div>
 					</br>
 						<h4 class="redli">Finding the Data</h4>
-						You can <a target="_parent" href="  https://204.68.210.15/gis/Housing/SanFranciscoHFDS20130621.zip"> download the data for San Francisco here.</a>
+						You can <a target="_parent" href="https://extxfer.sfdph.org/gis/Housing/SanFranciscoHFDS20130621.zip"> download the data for San Francisco here.</a>
 
 						<p>We will encourage other cities to host their data on public portals, and aggregate a list of end points as data is made available.
 						</p>


### PR DESCRIPTION
The destination of the data download link on the home page is: "204.68.210.15". However, when you click on it, the browser warns you that the server identifies itself differently (as "extxfer.sfdph.org").

In reality these are both the same site, but the website name should be used instead of the raw IP address to avoid these conflicts.

Screenshot below.

![ssl_bad_cert](https://f.cloud.github.com/assets/1596394/713833/3342f9c4-dee0-11e2-87f9-4d8d048de681.jpg)
