### PR TITLE
Update link for SF data 

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@ Like other civic data standards, this “machine-readable” format enables the 
 						</div>
 					</br>
 						<h4 class="redli">Finding the Data</h4>
-						You can <a target="_parent" href="  https://204.68.210.15/gis/Housing/SanFranciscoHFDS20130621.zip"> download the data for San Francisco here.</a>
+						You can <a target="_parent" href="https://data.sfgov.org/Public-Health/Housing-Code-Violations-San-Francisco-CA/739v-w6y3"> download the data for San Francisco here.</a>
 
 						<p>We will encourage other cities to host their data on public portals, and aggregate a list of end points as data is made available.
 						</p>


### PR DESCRIPTION
Resolve #11:

"Under the "details" section were currently linking to a download of deprecated data. Let's redirect that link to the DataSF page where it will always be most current:"

https://data.sfgov.org/Public-Health/Housing-Code-Violations-San-Francisco-CA/739v-w6y3
